### PR TITLE
Fix edit date warning modal conditions, switch to formData for .put/ account-info

### DIFF
--- a/src/core/components/pages/AccountPages/AccountPageUI/EditAccount.tsx
+++ b/src/core/components/pages/AccountPages/AccountPageUI/EditAccount.tsx
@@ -34,8 +34,10 @@ export default function EditAccount({ toggleEditButton, user }: AccountProps) {
   }
 
   const postDataToBackend = (data: EdittedData) => {
+    const formData = new FormData()
+    formData.append("data", JSON.stringify({ ...data }))
     client
-      .put<EdittedData>("/account_info", data)
+      .put<EdittedData>("/account_info", formData)
       .then(() => {
         window.location.reload()
       })

--- a/src/core/components/pages/AccountPages/AccountPageUI/OtherEdit.tsx
+++ b/src/core/components/pages/AccountPages/AccountPageUI/OtherEdit.tsx
@@ -77,7 +77,7 @@ export default function OtherAccountEdit({ registrationInfo, isRegister }: Regis
         })
     } else {
       client
-        .put<Other>("/account_info/", { ...data, is_thai_language: language === "th", ...registrationInfo, birthday: date.toString() })
+        .put<Other>("/account_info/", formData)
         .then(({ data }) => {
           if (data.verification_status === "Submitted") {
             formData.delete("data")

--- a/src/core/components/pages/staff-pages/interfaces/InfoInterface.tsx
+++ b/src/core/components/pages/staff-pages/interfaces/InfoInterface.tsx
@@ -30,6 +30,7 @@ export default interface Info {
 
 export interface OtherComponentInfo extends Info {
   previous_payment_slips: string[]
+  account_expiration_date: Date | string
 }
 
 export interface VerifyComponentSatitInfo {

--- a/src/core/components/pages/staff-pages/list-of-all-users-pages/UserInfo.tsx
+++ b/src/core/components/pages/staff-pages/list-of-all-users-pages/UserInfo.tsx
@@ -72,6 +72,7 @@ const UserInfo = () => {
     relationship_verification_document: "",
     payment_slip: "",
     previous_payment_slips: [],
+    account_expiration_date: "",
   })
   // temp data
   const [tempIsPenalize, setTempPenalize] = useState<boolean>(false)
@@ -82,7 +83,7 @@ const UserInfo = () => {
   // react router dom
   const { _id } = useParams<{ _id: string }>()
   const methods = useForm({ resolver: yupResolver(editInfoSchema) })
-  const { register } = methods
+  const { register, getValues } = methods
   const history = useHistory()
 
   // requests //
@@ -133,6 +134,7 @@ const UserInfo = () => {
           relationship_verification_document: data.relationship_verification_document,
           payment_slip: data.payment_slip,
           previous_payment_slips: data.previous_payment_slips,
+          account_expiration_date: data.account_expiration_date,
         })
         setIsLoading(false)
       })
@@ -222,13 +224,23 @@ const UserInfo = () => {
   }
 
   const handleSave = (canSave: boolean, newPenExp: Date, newAccExp: Date, newFileList: (File | undefined)[]) => {
-    if (!accountExpiredDate && info.verification_status === "Submitted") setShowModalInfo("showNotVerified")
-    else if (canSave && (!tempIsPenalize || (newPenExp >= new Date() && newAccExp >= new Date()))) {
+    if (
+      (getValues("tempAccountExpiredDate") !== "" || getValues("tempAccountExpiredTime")) !== "" &&
+      (info.verification_status === "Rejected" || info.verification_status === "Submitted")
+    ) {
+      setShowModalInfo("showNotVerified")
+    } else if (canSave && (!tempIsPenalize || (newPenExp >= new Date() && newAccExp >= new Date()))) {
       setTempExpiredPenalizeDate(newPenExp ? newPenExp : null)
       setTempAccountExpiredDate(newAccExp ? newAccExp : null)
       setFileList(newFileList)
       setShowModalInfo("showSave")
-    } else setShowModalInfo("showUncomExpire")
+    } else {
+      if (info.verification_status === "Verified") setShowModalInfo("showUncomExpire")
+      else {
+        setFileList(newFileList)
+        setShowModalInfo("showSave")
+      }
+    }
   }
 
   const handleUpload = async (typename: string, file: File) => {

--- a/src/core/components/ui/login/registerSatit.tsx
+++ b/src/core/components/ui/login/registerSatit.tsx
@@ -43,13 +43,14 @@ export const RegisterSatit = ({ user }: satitRejectedProps) => {
   }
 
   const postDataToBackend = (data: satitRegistrationInfo) => {
+    data["personal_email"] = data.username
     const formData = new FormData()
     formData.append("data", JSON.stringify(data))
     if (student_card_photo) formData.append("student_card_photo", student_card_photo, student_card_photo.name)
     setLoading(true)
     user
       ? client
-          .put<SatitCuPersonel>("/account_info", { ...data, personal_email: user.username })
+          .put<SatitCuPersonel>("/account_info", formData)
           .then(() => {
             if (student_card_photo) uploadStudentCardPhoto(student_card_photo)
             setLoading(false)


### PR DESCRIPTION
- make changes to the condition that will open the warning modal when staff tries to change the expiration date before approving that user
- switch to formData for .put /account-info as requested by backend