### PR TITLE
Redirect staff to login page if the staff visits user's pages

### DIFF
--- a/src/core/components/pages/front-login.tsx
+++ b/src/core/components/pages/front-login.tsx
@@ -7,10 +7,10 @@ import PersonalInfo from "../ui/login/personal-info-form"
 
 const FrontLoginPage = () => {
   const { path } = useRouteMatch()
-  const { isUser } = useAuthContext()
+  const { isUser, role } = useAuthContext()
   return (
     <>
-      {isUser && <Redirect to="/home" />}
+      {isUser && role === "User" && <Redirect to="/home" />}
       <Switch>
         <Route path={`${path}/personal`} component={PersonalInfo} />
         <Route exact path={path} component={FrontLoginMain} />

--- a/src/core/guards/user.guard.tsx
+++ b/src/core/guards/user.guard.tsx
@@ -5,8 +5,8 @@ import { useAuthContext } from "../controllers/authContext"
 
 function withUserGuard<P>(Component: ComponentType<P>): FC<P> {
   return function WithUserGuard(props: P) {
-    const { isUser } = useAuthContext()
-    if (!isUser && getCookie("token") === undefined) {
+    const { isUser, role } = useAuthContext()
+    if (isUser && (role !== "User" || getCookie("token") === undefined)) {
       return <Redirect to="/login" />
     } else {
       return <Component {...props} />


### PR DESCRIPTION
# Problem
- The staff sees an infinite loading indicator when visiting user's pages without signing in as a user

# Solution
- Modify the rules in user.guard to take the roles into consideration as well