### PR TITLE
Restrict staff from deleting reservations and waiting rooms

### DIFF
--- a/src/core/components/pages/staff-pages/all-reservation-pages/ReservationDetail.tsx
+++ b/src/core/components/pages/staff-pages/all-reservation-pages/ReservationDetail.tsx
@@ -183,15 +183,17 @@ const ReservationDetail: React.FC = () => {
             </Link>
           </Col>
           <Col>
-            <Button
-              variant="danger"
-              className="float-right btn-normal btn-outline-red"
-              onClick={() => {
-                setShowConfirmDel(true)
-              }}
-            >
-              ลบการจอง
-            </Button>
+            {role === "Admin" && (
+              <Button
+                variant="danger"
+                className="float-right btn-normal btn-outline-red"
+                onClick={() => {
+                  setShowConfirmDel(true)
+                }}
+              >
+                ลบการจอง
+              </Button>
+            )}
           </Col>
         </Row>
         {modals}


### PR DESCRIPTION
# Requested Changes
- Added`jwt` role check to ensure that staff no longer has the ability to delete `Reservations` and and `Waiting Rooms`