### PR TITLE
feat: save filter in query params

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "jwt-decode": "^3.1.2",
     "popper.js": "^1.16.1",
     "qrcode.react": "^1.0.1",
+    "qs": "^6.10.3",
     "react": "^16.13.1",
     "react-bootstrap": "^1.3.0",
     "react-bootstrap-icons": "^1.2.3",
@@ -78,6 +79,7 @@
     ]
   },
   "devDependencies": {
+    "@types/qs": "^6.9.7",
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
     "eslint-config-prettier": "^7.1.0",

--- a/src/core/components/pages/staff-pages/disable-court/list-of-courts.tsx
+++ b/src/core/components/pages/staff-pages/disable-court/list-of-courts.tsx
@@ -43,8 +43,7 @@ const ListOfCourts = () => {
   const refreshData = async (event: React.ChangeEvent<HTMLInputElement>) => {
     console.log(event.target.name, event.target.value)
     if (event.target.name === "sports") {
-      const courtNum = event.target.value === "ประเภทกีฬา" || !queryParams.courtNum ? "" : queryParams.courtNum
-      updateQuery({ sports: event.target.value, courtNum })
+      updateQuery({ sports: event.target.value, courtNum: undefined })
     } else {
       updateQuery({ courtNum: event.target.value })
     }

--- a/src/core/components/pages/staff-pages/disable-court/list-of-courts.tsx
+++ b/src/core/components/pages/staff-pages/disable-court/list-of-courts.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react"
+import React, { useRef, useEffect } from "react"
 
 import { Form, Button, Pagination } from "react-bootstrap"
 import { useRouteMatch, useHistory } from "react-router-dom"
@@ -10,17 +10,27 @@ import { DeleteButton } from "./button"
 import { CourtTable, CourtRow } from "./disabled-court-table"
 import { ListOfCourtsForm, RowProps } from "../../../../dto/disableCourt.dto"
 import { useAuthContext } from "../../../../controllers/authContext"
+import { useQueryParams } from "../../../../utils/qs"
 
 const ListOfCourts = () => {
   const history = useHistory()
   const startDateRef = useRef<DatePicker>(null)
   const endDateRef = useRef<DatePicker>(null)
   const { path } = useRouteMatch()
-  const { data, maxPage, page, setPage, jumpUp, jumpDown, setParams, pageArr, onDelete, isError, setIsError } = useTableWithPagination()
-  const { register, handleSubmit, control, setValue } = useForm<ListOfCourtsForm>()
-  const { startDate, endDate, onStartDateChange, onEndDateChange, showDateError, handleAlert, setStartDate, setEndDate } = useDate()
+  const { data, maxPage, page, setPage, jumpUp, jumpDown, pageArr, onDelete, isError, setIsError } = useTableWithPagination()
+  const { queryParams, updateQuery } = useQueryParams()
+  const { register, control, setValue, reset } = useForm<ListOfCourtsForm>({
+    defaultValues: {
+      sports: queryParams.sports,
+      courtNum: queryParams.courtNum,
+    },
+  })
+  const { startDate, endDate, onStartDateChange, onEndDateChange, showDateError, handleAlert, setStartDate, setEndDate } = useDate(
+    queryParams.startDate ? new Date(queryParams.startDate) : undefined,
+    queryParams.endDate ? new Date(queryParams.endDate) : undefined
+  )
   const watchSports = useWatch({ control, name: "sports", defaultValue: "" })
-  const { option } = useOption()
+  const { option } = useOption(reset)
   const { role } = useAuthContext()
 
   const onSelectStartDate = () => {
@@ -30,20 +40,20 @@ const ListOfCourts = () => {
     endDateRef.current?.setOpen(true)
   }
 
-  const validateFilter = async (event: React.ChangeEvent<HTMLInputElement>) => {
-    if (event.target.value === "ประเภทกีฬา" || !event.target.value) setValue("courtNum", "เลขคอร์ด")
+  const refreshData = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    console.log(event.target.name, event.target.value)
+    if (event.target.name === "sports") {
+      const courtNum = event.target.value === "ประเภทกีฬา" || !queryParams.courtNum ? "" : queryParams.courtNum
+      updateQuery({ sports: event.target.value, courtNum })
+    } else {
+      updateQuery({ courtNum: event.target.value })
+    }
   }
 
-  const onSubmit = (form: ListOfCourtsForm) => {
-    setParams({
-      sportObjId: form.sports ? form.sports : undefined,
-      starting_date: startDate,
-      expired_date: endDate,
-      court_num: form.courtNum ? parseInt(form.courtNum) : undefined,
-      start: 0,
-      end: 9,
-    })
-  }
+  useEffect(() => {
+    setValue("sports", queryParams.sports)
+    setValue("courtNum", queryParams.courtNum)
+  }, [queryParams.sports, queryParams.courtNum, setValue])
 
   const onAdd = () => history.push(`${path}/add`)
   return (
@@ -51,11 +61,11 @@ const ListOfCourts = () => {
       <ErrorAlert inProp={isError} handleClose={() => setIsError(false)} header="การลบคอร์ด" message="ไม่สามารถลบคอร์ดได้ กรุณาลองอีกครั้ง" />
       <ErrorAlert inProp={showDateError} handleClose={handleAlert} header="วันที่ไม่ถูกต้อง" message="วันที่ไม่ถูกต้อง" />
       <div className="disable-court-wrapper px-1 py-2 mt-3">
-        <Form className="disable-court-filter" onSubmit={handleSubmit(onSubmit)}>
+        <Form className="disable-court-filter">
           <div className="d-flex flex-row align-items-center justify-content-between">
             <div className="d-flex flex-row align-items-center w-100">
               <Form.Label srOnly={true}>ประเภทกีฬา</Form.Label>
-              <Form.Control name="sports" as="select" ref={register} onChange={validateFilter}>
+              <Form.Control name="sports" as="select" ref={register} onChange={refreshData}>
                 <option value={""}>ประเภทกีฬา</option>
                 {option ? (
                   option.map((sport) => (
@@ -67,7 +77,7 @@ const ListOfCourts = () => {
                   <option value={""}>ประเภทกีฬา</option>
                 )}
               </Form.Control>
-              <Form.Control name="courtNum" as="select" ref={register} disabled={watchSports === "ประเภทกีฬา" ? true : false}>
+              <Form.Control name="courtNum" as="select" ref={register} onChange={refreshData} disabled={watchSports === "ประเภทกีฬา" ? true : false}>
                 <option value={""}>เลขคอร์ด</option>
                 {watchSports &&
                   option &&
@@ -86,7 +96,13 @@ const ListOfCourts = () => {
                   วันเริ่มต้นการล็อค
                 </label>
                 <DatePicker className="form-control" selected={startDate} onChange={onStartDateChange} name="somw" ref={startDateRef} />
-                <Button variant="outline-transparent" onClick={() => setStartDate(undefined)}>
+                <Button
+                  variant="outline-transparent"
+                  onClick={() => {
+                    setStartDate(undefined)
+                    updateQuery({ startDate: undefined })
+                  }}
+                >
                   ลบ
                 </Button>
               </div>
@@ -95,14 +111,26 @@ const ListOfCourts = () => {
                   วันสิ้นสุดการล็อค
                 </label>
                 <DatePicker className="form-control" selected={endDate} onChange={onEndDateChange} ref={endDateRef} />
-                <Button variant="outline-transparent" onClick={() => setEndDate(undefined)}>
+                <Button
+                  variant="outline-transparent"
+                  onClick={() => {
+                    setEndDate(undefined)
+                    updateQuery({ endDate: undefined })
+                  }}
+                >
                   ลบ
                 </Button>
               </div>
+              <Button
+                className="disable-court-button"
+                variant="pink"
+                onClick={() => {
+                  updateQuery({ sports: undefined, courtNum: undefined, startDate: undefined, endDate: undefined })
+                }}
+              >
+                ลบการกรอง
+              </Button>
             </div>
-            <Button className="disable-court-button" type="submit" variant="pink">
-              ค้นหา
-            </Button>
           </div>
         </Form>
       </div>

--- a/src/core/components/pages/staff-pages/disable-court/viewCourt.tsx
+++ b/src/core/components/pages/staff-pages/disable-court/viewCourt.tsx
@@ -145,7 +145,7 @@ const ViewCourt = () => {
         <div className="d-flex flex-row justify-content-end">
           {!isEdit ? (
             <>
-              <Button variant="outline-pink" className="mr-2" onClick={() => history.push("/staff/disableCourt")} style={{ fontSize: "20px" }}>
+              <Button variant="outline-pink" className="mr-2" onClick={() => history.goBack()} style={{ fontSize: "20px" }}>
                 กลับ
               </Button>
               {role === "Admin" && (

--- a/src/core/utils/qs.tsx
+++ b/src/core/utils/qs.tsx
@@ -9,7 +9,7 @@ export function useQueryParams() {
 
   const updateQuery = (queries: Record<string, string | undefined>) => {
     const newQs = { ...queryParams, ...queries }
-    history.push({
+    history.replace({
       search: qs.stringify(newQs),
     })
   }

--- a/src/core/utils/qs.tsx
+++ b/src/core/utils/qs.tsx
@@ -1,0 +1,20 @@
+import { useHistory, useLocation } from "react-router-dom"
+import qs from "qs"
+
+export function useQueryParams() {
+  const { search } = useLocation()
+  const history = useHistory()
+
+  const queryParams = qs.parse(search.substring(1)) as Record<string, string> // remove '?'
+
+  const updateQuery = (queries: Record<string, string | undefined>) => {
+    const newQs = { ...queryParams, ...queries }
+    history.push({
+      search: qs.stringify(newQs),
+    })
+  }
+  return {
+    queryParams,
+    updateQuery,
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1807,6 +1807,11 @@
   dependencies:
     "@types/react" "*"
 
+"@types/qs@^6.9.7":
+  version "6.9.7"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
+  integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
+
 "@types/react-bootstrap@^0.32.24":
   version "0.32.25"
   resolved "https://registry.yarnpkg.com/@types/react-bootstrap/-/react-bootstrap-0.32.25.tgz#fdea798f9a2623a161ed61939898078ae841df1e"
@@ -9571,6 +9576,13 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
+qs@^6.10.3:
+  version "6.10.3"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.3.tgz#d6cde1b2ffca87b5aa57889816c5f81535e22e8e"
+  integrity sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==
+  dependencies:
+    side-channel "^1.0.4"
+
 qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
@@ -10721,7 +10733,7 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-side-channel@^1.0.2, side-channel@^1.0.3:
+side-channel@^1.0.2, side-channel@^1.0.3, side-channel@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
   integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==


### PR DESCRIPTION
- changing filter results in new history being replaced in, re-triggering initial fetch with search filter
- no need to hit submit -> change to clear filter instead
- filter is preserved in query string, so pressing back will preserve state